### PR TITLE
Replace pipes with list-transformer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.stack-work/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+0.2.0.0
+-------
+* Change type of `runNondeterminism`
+* Add `runNondeterminismM`

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,3 @@
+resolver: lts-7.11
+extra-deps:
+  - list-transformer-1.0.1

--- a/transformers-eff.cabal
+++ b/transformers-eff.cabal
@@ -6,18 +6,18 @@ license:             BSD3
 license-file:        LICENSE
 author:              Ollie Charles
 maintainer:          ollie@ocharles.org.uk
--- copyright:           
+-- copyright:
 category:            Control
 build-type:          Simple
--- extra-source-files:  
+-- extra-source-files:
 cabal-version:       >=1.10
 
 library
   exposed-modules:     Control.Effect, Control.Effect.Environment, Control.Effect.Nondeterminism, Control.Effect.Exception, Control.Effect.IO, Control.Effect.State, Control.Effect.Identity
-  -- other-modules:       
+  -- other-modules:
   other-extensions:    TypeOperators, DeriveDataTypeable, DefaultSignatures, DeriveFunctor, StandaloneDeriving, ExistentialQuantification, FlexibleContexts, FlexibleInstances, FunctionalDependencies, KindSignatures, RankNTypes, UndecidableInstances, MultiParamTypeClasses, GeneralizedNewtypeDeriving
-  build-depends:       base >=4.8 && <5, transformers >=0.4 && <0.6, pipes, free, mmorph
-  -- hs-source-dirs:      
+  build-depends:       base >=4.8 && <5, transformers >=0.4 && <0.6, list-transformer, free, mmorph
+  -- hs-source-dirs:
   default-language:    Haskell2010
   ghc-options: -Wall
 

--- a/transformers-eff.cabal
+++ b/transformers-eff.cabal
@@ -1,6 +1,6 @@
 name:                transformers-eff
 synopsis:            An approach to managing composable effects, ala mtl/transformers/extensible-effects/Eff
-version:             0.1.0.0
+version:             0.2.0.0
 homepage:            https://github.com/ocharles/transformers-eff
 license:             BSD3
 license-file:        LICENSE
@@ -9,7 +9,8 @@ maintainer:          ollie@ocharles.org.uk
 -- copyright:
 category:            Control
 build-type:          Simple
--- extra-source-files:
+extra-source-files:
+  CHANGELOG.md
 cabal-version:       >=1.10
 
 library


### PR DESCRIPTION
I believe `Pipes` is only used for its `ListT` implementation, but Gabriel more recently released `list-transformer`, which seems much more lightweight.

Also, I left the return type as `ListT m a` (rather than `m [a]` like before), because it seemed like the more "natrual" embedding, but the old behavior is easy to get.

Are you interested in this change? If so - still TODO are: fix benchmarks, fix shell.nix (I don't use nix), and possibly go back to `m [a]` as:

```haskell
runNondeterminism :: Monad m => Eff [] m a -> m [a]
runNondeterminism = fold (\x a -> x . (a:)) id ($ []) . translate (lift . select)
```

Thanks!