### PR TITLE
Updating State.gets to Have the Correct Type Signature

### DIFF
--- a/Control/Effect/State.hs
+++ b/Control/Effect/State.hs
@@ -37,6 +37,6 @@ modify' :: (Interprets (State state) m) => (state -> state) -> m ()
 modify' f = interpret (State.modify' f)
 {-# INLINE modify' #-}
 
-gets :: (Interprets (State state) m) => (state -> state) -> m state
+gets :: (Interprets (State state) m) => (state -> a) -> m a
 gets f = interpret (State.gets f)
 {-# INLINE gets #-}


### PR DESCRIPTION
```
gets :: (Interprets (State state) m) => (state -> state) -> m state
```

Is not nearly as useful as:

```
gets :: (Interprets (State state) m) => (state -> a) -> m a
```
