### PR TITLE
Generalise Nondeterminism over any Foldable

### DIFF
--- a/Control/Effect/Nondeterminism.hs
+++ b/Control/Effect/Nondeterminism.hs
@@ -9,8 +9,6 @@ import Control.Effect
 import Data.Foldable (Foldable, toList)
 import List.Transformer (fold, foldM, select)
 
--- TODO Can probably generalize over any foldable.
-
 class Monad m => Nondeterministic m where
   liftNondeterminism :: [a] -> m a
 

--- a/Control/Effect/Nondeterminism.hs
+++ b/Control/Effect/Nondeterminism.hs
@@ -6,6 +6,7 @@ module Control.Effect.Nondeterminism where
 import Control.Monad (join)
 import Control.Monad.Trans.Class (lift)
 import Control.Effect
+import Data.Foldable (Foldable, toList)
 import List.Transformer (fold, foldM, select)
 
 -- TODO Can probably generalize over any foldable.
@@ -21,15 +22,15 @@ instance {-# OVERLAPPABLE #-} (Nondeterministic m) => Nondeterministic (Eff f m)
   liftNondeterminism = lift . liftNondeterminism
   {-# INLINE liftNondeterminism #-}
 
-choose :: Nondeterministic m => [a] -> m a
-choose = liftNondeterminism
+choose :: (Nondeterministic m, Foldable f) => f a -> m a
+choose = liftNondeterminism . toList
 {-# INLINE choose #-}
 
-runNondeterminism :: Monad m => (b -> a -> b) -> b -> Eff [] m a -> m b
+runNondeterminism :: (Monad m, Foldable f) => (b -> a -> b) -> b -> Eff f m a -> m b
 runNondeterminism f z = fold f z id . translate (lift . select)
 {-# INLINE runNondeterminism #-}
 
-runNondeterminismM :: Monad m => (b -> a -> m b) -> m b -> Eff [] m a -> m b
+runNondeterminismM :: (Monad m, Foldable f) => (b -> a -> m b) -> m b -> Eff f m a -> m b
 runNondeterminismM f z = foldM f z return . translate (lift . select)
 {-# INLINE runNondeterminismM #-}
 


### PR DESCRIPTION
Not sure if this is what 'TODO Can probably generalize over any foldable.' envisaged, but here it is anyway!

Potentially something not-entirely-thought-out could be of use:

```
runMaybe :: (Monad m, Foldable f) => Eff f m a -> m (Maybe a)
runMaybe = runNondeterminism (\m x -> maybe (Just x) Just m) Nothing
```